### PR TITLE
add self signed tls with iocage set

### DIFF
--- a/overlay/usr/local/bin/mosquitto-generate-tlscert
+++ b/overlay/usr/local/bin/mosquitto-generate-tlscert
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# CN must be the name specified by -h in mosquitto_pub/sub, e.g.
+# mosquitto_pub -h 192.168.1.0 -p 8883 --cafile ca.crt -t \$SYS/broker/bytes/\#
+# mosquitto_pub -h mqtt.example.com -p 8883 --cafile ca.crt -t \$SYS/broker/bytes/\#
+CN=$1
+
+C="MQ"
+ST="TT"
+L="mosquitto"
+O="ca.example.com"
+OU="mosquitto-ca"
+emailAddress="mosquitto@example.com"
+
+TLS_DIR="/home/sam/Documents/iocage-mosquitto/overlay/usr/local/etc/mosquitto"
+mkdir -p $TLS_DIR
+
+# create a CA private key
+openssl genrsa -out "${TLS_DIR}/ca.key" 2048
+# create a CA public key / certificate
+openssl req -new -x509 -days 1826 -key "${TLS_DIR}/ca.key" -out "${TLS_DIR}/ca.crt" -subj "/C=${C}/ST=${ST}/L=${L}/O=${O}/OU=${OU}/CN=${CN}/emailAddress=${emailAddress}"
+
+# Apparently subj must vary by atleast 1 character
+OU="mosquitto-server"
+
+# create a server private key
+openssl genrsa -out "${TLS_DIR}/server.key" 2048
+# create a server certificate request
+openssl req -new -out "${TLS_DIR}/server.csr" -key "${TLS_DIR}/server.key" -subj "/C=${C}/ST=${ST}/L=${L}/O=${O}/OU=${OU}/CN=${CN}/emailAddress=${emailAddress}"
+# create a server public key / certificate
+openssl x509 -req -in "${TLS_DIR}/server.csr" -CA "${TLS_DIR}/ca.crt" -CAkey "${TLS_DIR}/ca.key" -CAcreateserial -out "${TLS_DIR}/server.crt" -days 360
+
+# Apparently subj must vary by atleast 1 character
+OU="mosquitto-client"
+
+# creata a client private key
+openssl genrsa -out "${TLS_DIR}/client.key" 2048
+# create a client certificate request
+openssl req -new -key "${TLS_DIR}/client.key" -out "${TLS_DIR}/client.csr" -subj "/C=${C}/ST=${ST}/L=${L}/O=${O}/OU=${OU}/CN=${CN}/emailAddress=${emailAddress}"
+# create a client public key / certificate
+openssl x509 -req -in "${TLS_DIR}/client.csr" -CA "${TLS_DIR}/ca.crt" -CAkey "${TLS_DIR}/ca.key" -CAcreateserial -out "${TLS_DIR}/client.crt" -days 360 -addtrust clientAuth

--- a/overlay/usr/local/bin/mosquitto-generate-tlscert
+++ b/overlay/usr/local/bin/mosquitto-generate-tlscert
@@ -12,7 +12,7 @@ O="ca.example.com"
 OU="mosquitto-ca"
 emailAddress="mosquitto@example.com"
 
-TLS_DIR="/home/sam/Documents/iocage-mosquitto/overlay/usr/local/etc/mosquitto"
+TLS_DIR="/usr/local/etc/mosquitto"
 mkdir -p $TLS_DIR
 
 # create a CA private key

--- a/overlay/usr/local/bin/mosquitto-generate-tlscert
+++ b/overlay/usr/local/bin/mosquitto-generate-tlscert
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # CN must be the name specified by -h in mosquitto_pub/sub, e.g.
-# mosquitto_pub -h 192.168.1.0 -p 8883 --cafile ca.crt -t \$SYS/broker/bytes/\#
-# mosquitto_pub -h mqtt.example.com -p 8883 --cafile ca.crt -t \$SYS/broker/bytes/\#
+# mosquitto_sub -h 192.168.1.0 -p 8883 --cafile ca.crt -t \$SYS/broker/bytes/\#
+# mosquitto_sub -h mqtt.example.com -p 8883 --cafile ca.crt -t \$SYS/broker/bytes/\#
 CN=$1
 
 C="MQ"

--- a/overlay/usr/local/bin/mosquittoset
+++ b/overlay/usr/local/bin/mosquittoset
@@ -4,6 +4,9 @@
 # Example use: sudo iocage set -P allow_anonymous=false mosquitto
 # Example use: sudo iocage set -P adduser=username,password mosquitto
 # Example use: sudo iocage set -P deluser=username mosquitto
+# Example use: sudo iocage set -P addtls=mqtt.example.com mosquitto
+# Example use: sudo iocage set -P deltls=true mosquitto
+
 
 _CONFIG="/usr/local/etc/mosquitto/mosquitto.conf"
 _PWFILE="/usr/local/etc/mosquitto/pwfile"
@@ -26,6 +29,22 @@ else
 fi
 }
 
+set_tls_comments()
+{
+sed -i '' "s|cafile /usr/local/share/certs/ca-root-nss.crt|#cafile /usr/local/share/certs/ca-root-nss.crt|" $1
+sed -i '' "s|#cafile /usr/local/etc/mosquitto/ca.crt|cafile /usr/local/etc/mosquitto/ca.crt|" $1
+sed -i '' "s|#keyfile /usr/local/etc/mosquitto/server.crt|keyfile /usr/local/etc/mosquitto/server.key|" $1
+sed -i '' "s|#certfile /usr/local/etc/mosquitto/server.crt|certfile /usr/local/etc/mosquitto/server.crt|" $1
+}
+
+unset_tls_comments()
+{
+sed -i '' "s|#cafile /usr/local/share/certs/ca-root-nss.crt|cafile /usr/local/share/certs/ca-root-nss.crt|" $1
+sed -i '' "s|cafile /usr/local/etc/mosquitto/ca.crt|#cafile /usr/local/etc/mosquitto/ca.crt|" $1
+sed -i '' "s|keyfile /usr/local/etc/mosquitto/server.crt|#keyfile /usr/local/etc/mosquitto/server.key|" $1
+sed -i '' "s|certfile /usr/local/etc/mosquitto/server.crt|#certfile /usr/local/etc/mosquitto/server.crt|" $1
+}
+
 case $1 in
     port) sed -i '' "s/^port.*/port $2/" ${_CONFIG}
           give_message_config
@@ -38,6 +57,14 @@ case $1 in
           ;;
     deluser) mosquitto_passwd -D ${_PWFILE} $2
           give_message_pwfile
+          ;;
+    addtls) mosquitto-generate-tlscert $2
+          set_tls_comments ${_CONFIG}
+          give_message_config
+          ;;
+    deltls) unset_tls_comments ${_CONFIG}
+          rm -f /usr/local/etc/mosquitto/{ca.crt,ca.key,ca.srl,client.crt,client.csr,client.key,server.crt,server.csr,server.key}
+          give_message_config
           ;;
     *) echo "Unknown option">&2 ; exit 1
           ;;

--- a/overlay/usr/local/bin/mosquittoset
+++ b/overlay/usr/local/bin/mosquittoset
@@ -33,7 +33,7 @@ set_tls_comments()
 {
 sed -i '' "s|cafile /usr/local/share/certs/ca-root-nss.crt|#cafile /usr/local/share/certs/ca-root-nss.crt|" $1
 sed -i '' "s|#cafile /usr/local/etc/mosquitto/ca.crt|cafile /usr/local/etc/mosquitto/ca.crt|" $1
-sed -i '' "s|#keyfile /usr/local/etc/mosquitto/server.crt|keyfile /usr/local/etc/mosquitto/server.key|" $1
+sed -i '' "s|#keyfile /usr/local/etc/mosquitto/server.key|keyfile /usr/local/etc/mosquitto/server.key|" $1
 sed -i '' "s|#certfile /usr/local/etc/mosquitto/server.crt|certfile /usr/local/etc/mosquitto/server.crt|" $1
 }
 
@@ -41,7 +41,7 @@ unset_tls_comments()
 {
 sed -i '' "s|#cafile /usr/local/share/certs/ca-root-nss.crt|cafile /usr/local/share/certs/ca-root-nss.crt|" $1
 sed -i '' "s|cafile /usr/local/etc/mosquitto/ca.crt|#cafile /usr/local/etc/mosquitto/ca.crt|" $1
-sed -i '' "s|keyfile /usr/local/etc/mosquitto/server.crt|#keyfile /usr/local/etc/mosquitto/server.key|" $1
+sed -i '' "s|keyfile /usr/local/etc/mosquitto/server.key|#keyfile /usr/local/etc/mosquitto/server.key|" $1
 sed -i '' "s|certfile /usr/local/etc/mosquitto/server.crt|#certfile /usr/local/etc/mosquitto/server.crt|" $1
 }
 
@@ -61,10 +61,12 @@ case $1 in
     addtls) mosquitto-generate-tlscert $2
           set_tls_comments ${_CONFIG}
           give_message_config
+          echo "consider chaning port to 8883, the default tls port for mqtt"
           ;;
     deltls) unset_tls_comments ${_CONFIG}
           rm -f /usr/local/etc/mosquitto/{ca.crt,ca.key,ca.srl,client.crt,client.csr,client.key,server.crt,server.csr,server.key}
           give_message_config
+          echo "consider chaning port to 1883, the default port for mqtt"
           ;;
     *) echo "Unknown option">&2 ; exit 1
           ;;

--- a/overlay/usr/local/bin/mosquittoset
+++ b/overlay/usr/local/bin/mosquittoset
@@ -61,11 +61,21 @@ case $1 in
     addtls) mosquitto-generate-tlscert $2
           set_tls_comments ${_CONFIG}
           give_message_config
+          sleep 5
           echo "consider chaning port to 8883, the default tls port for mqtt"
           ;;
     deltls) unset_tls_comments ${_CONFIG}
-          rm -f /usr/local/etc/mosquitto/{ca.crt,ca.key,ca.srl,client.crt,client.csr,client.key,server.crt,server.csr,server.key}
+          rm -f /usr/local/etc/mosquitto/ca.crt
+          rm -f /usr/local/etc/mosquitto/ca.key
+          rm -f /usr/local/etc/mosquitto/ca.srl
+          rm -f /usr/local/etc/mosquitto/client.crt
+          rm -f /usr/local/etc/mosquitto/client.csr
+          rm -f /usr/local/etc/mosquitto/client.key
+          rm -f /usr/local/etc/mosquitto/server.crt
+          rm -f /usr/local/etc/mosquitto/server.csr
+          rm -f /usr/local/etc/mosquitto/server.key
           give_message_config
+          sleep 5
           echo "consider chaning port to 1883, the default port for mqtt"
           ;;
     *) echo "Unknown option">&2 ; exit 1

--- a/overlay/usr/local/bin/mosquittoset
+++ b/overlay/usr/local/bin/mosquittoset
@@ -61,8 +61,6 @@ case $1 in
     addtls) mosquitto-generate-tlscert $2
           set_tls_comments ${_CONFIG}
           give_message_config
-          sleep 5
-          echo "consider chaning port to 8883, the default tls port for mqtt"
           ;;
     deltls) unset_tls_comments ${_CONFIG}
           rm -f /usr/local/etc/mosquitto/ca.crt
@@ -75,8 +73,6 @@ case $1 in
           rm -f /usr/local/etc/mosquitto/server.csr
           rm -f /usr/local/etc/mosquitto/server.key
           give_message_config
-          sleep 5
-          echo "consider chaning port to 1883, the default port for mqtt"
           ;;
     *) echo "Unknown option">&2 ; exit 1
           ;;

--- a/overlay/usr/local/etc/mosquitto/mosquitto.conf.plugin
+++ b/overlay/usr/local/etc/mosquitto/mosquitto.conf.plugin
@@ -15,6 +15,9 @@ port 1883
 
 # At least one of cafile or capath must be defined.
 cafile /usr/local/share/certs/ca-root-nss.crt
+#cafile /usr/local/etc/mosquitto/ca.crt
+#keyfile /usr/local/etc/mosquitto/server.key
+#certfile /usr/local/etc/mosquitto/server.crt
 
 # Save persistent message data to disk (true/false).
 # This saves information about all messages, including subscriptions, 

--- a/settings.json
+++ b/settings.json
@@ -40,6 +40,24 @@
 			"name": "Delete User",
 			"description": "Remove a MQTT user",
 			"requirerestart": true
+		},
+		"addtls":{
+			"type": "add",
+			"name": "Add tls listening",
+			"description": "Generate certs and keys for a self signed encrypted tls listening",
+			"requiredargs": {
+				"hostname": {
+					"type": "string",
+					"description": "hostname specified by -h flag on mosquitto_pub/sub"
+				}
+			},
+			"requirerestart": true
+		},
+		"deltls":{
+			"type": "delete",
+			"name": "Remove tls listening",
+			"description": "Delete certs and keys for a self signed encrypted tls listening",
+			"requirerestart": true
 		}
 	}
 }


### PR DESCRIPTION
Hello again,

I was inspired by the heimdall plugin's self signed certificate option and made an attempt for mosquitto. Please consider these changes.

Example tls usage, on the freenas host, after installing the plugin with name mosquitto:
```
sudo iocage set -P addtls=mqtt.example.com mosquitto
sudo iocage set -P port=8883 mosquitto
```
then from any `mosquitto_sub` client with a copy of `/usr/local/etc/mosquitto/ca.crt` from the plugin
```
mosquitto_sub -h mqtt.example.com -p 8883 --cafile ca.crt -t \$SYS/broker/bytes/\#
```
or using the client key and cert
```
mosquitto_sub -h mqtt.example.com -p 8883 --cafile ca.crt --cert client.crt --key client.key -t \$SYS/broker/bytes/\#
```
of course, mqtt.example.com may be an ip address like 192.168.1.0

To revert to the original state:
```
sudo iocage set -P deltls=true mosquitto
sudo iocage set -P port=1883 mosquitto
```